### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
     "type": "git",
     "url": "git://github.com/pascalduez/sassdoc-utils.git"
   },
-  "license": {
-    "type": "unlicence",
-    "url": "http://unlicense.org"
-  },
+  "license": "Unlicence",
   "files": [
     "dist",
     "index.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git://github.com/pascalduez/sassdoc-utils.git"
   },
-  "license": "Unlicence",
+  "license": "Unlicense",
   "files": [
     "dist",
     "index.js",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
